### PR TITLE
Feature/tag modal

### DIFF
--- a/src/components/Main/Main.tsx
+++ b/src/components/Main/Main.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import { ToastContainer, Slide } from 'react-toastify';
 
+import TagModal from './MainModal/TagModal';
 import TotalTimeModal from './MainModal/TotalTimeModal';
 import MostUseTimeModal from './MainModal/MostUseTimeModal';
 import MainTitle from '@components/Main/MainContent/MainTitle';
@@ -104,6 +105,7 @@ const Main: React.FC<Props> = ({ rawKeyword, setRawKeyword, user }: Props) => {
           <MostVisitWebSIteModal />
           <TotalTimeModal />
           <MostUseTimeModal />
+          <TagModal />
           <ToastContainer
             position="bottom-center"
             autoClose={1500}

--- a/src/components/Main/MainContent/MainTitle.styled.ts
+++ b/src/components/Main/MainContent/MainTitle.styled.ts
@@ -62,7 +62,7 @@ export const TitleContainer = styled.div(() => [
 ]);
 
 export const Icon = styled.img(() => {
-  return [
+  return [tw`cursor-pointer`,
     css`
       width: 24px;
       height: 24px;
@@ -70,6 +70,7 @@ export const Icon = styled.img(() => {
     `,
   ];
 });
+
 
 export const TitleWrapper = styled.div(() => {
   return [

--- a/src/components/Main/MainContent/MainTitle.tsx
+++ b/src/components/Main/MainContent/MainTitle.tsx
@@ -2,11 +2,14 @@ import React from 'react';
 
 import SettingDropdown from './SettingDropdown';
 
+import { useAppDispatch } from '@redux/store';
+import { openModal } from '@redux/common';
+
 import { QuestionIcon } from '@assets/img/svg-icon-paths';
-import { UserEntity } from '@redux/webSerfer.type';
 
 import * as S from './MainTitle.styled';
 
+import { UserEntity } from '@redux/webSerfer.type';
 import { StatResponse } from '@redux/webSerfer.type';
 
 type Props = {
@@ -23,13 +26,25 @@ const MainTitle = ({ setIsSetting, isSetting, user, statData }: Props) => {
 
     return splitted || email || '김넥터';
   })();
+
+  const dispatch = useAppDispatch();
+
+  const requestOpenModal = () => {
+    dispatch(openModal('tag'));
+    console.log('click');
+  };
+
   return (
     <S.Wrapper imageUrl={statData.achievement.imageUrl}>
       <S.TitleContainer>
         <S.SubTitle>이번 주 {name} 님은</S.SubTitle>
         <S.TitleWrapper>
           <S.Title>{statData.achievement.name}</S.Title>
-          <S.Icon src={QuestionIcon} />
+          <S.Icon
+            src={QuestionIcon}
+            alt="서핑태그에 대해서..."
+            onClick={requestOpenModal}
+          />
         </S.TitleWrapper>
         <S.Description>
           {statData.achievement.category} 사이트 사용량이 많아요.

--- a/src/components/Main/MainModal/TagModal.Styled.ts
+++ b/src/components/Main/MainModal/TagModal.Styled.ts
@@ -32,7 +32,6 @@ export const Card = styled.div(() => {
     css`
       width: 233px;
       height: 270px;
-      margin-bottom: 20px;
       padding: 20px 20px 0 20px;
       background-color: ${theme.color.white};
       border-radius: 24px;

--- a/src/components/Main/MainModal/TagModal.Styled.ts
+++ b/src/components/Main/MainModal/TagModal.Styled.ts
@@ -6,6 +6,7 @@ export const Description = styled.div(() => {
   return [
     // tw``,
     css`
+      margin-top: 10px;
       margin-bottom: 40px;
       color: ${theme.color['gray-06']};
       font-size: ${theme.fontSize.m};
@@ -20,6 +21,7 @@ export const CardWrapper = styled.div(() => {
   return [
     tw`w-full flex flex-wrap`,
     css`
+      margin-bottom: 30px;
       gap: 20px;
     `,
   ];

--- a/src/components/Main/MainModal/TagModal.Styled.ts
+++ b/src/components/Main/MainModal/TagModal.Styled.ts
@@ -1,0 +1,78 @@
+import { css, useTheme } from '@emotion/react';
+import tw, { styled } from 'twin.macro';
+
+export const Description = styled.div(() => {
+  const theme = useTheme();
+  return [
+    // tw``,
+    css`
+      margin-bottom: 40px;
+      color: ${theme.color['gray-06']};
+      font-size: ${theme.fontSize.m};
+      font-weight: ${theme.fontWeight.regular};
+      line-height: ${theme.lineHeight.l};
+    `,
+  ];
+});
+
+export const CardWrapper = styled.div(() => {
+  const theme = useTheme();
+  return [
+    tw`w-full flex flex-wrap`,
+    css`
+      gap: 20px;
+    `,
+  ];
+});
+
+export const Card = styled.div(() => {
+  const theme = useTheme();
+  return [
+    // tw``,
+    css`
+      width: 233px;
+      height: 270px;
+      margin-bottom: 20px;
+      padding: 20px 20px 0 20px;
+      background-color: ${theme.color.white};
+      border-radius: 24px;
+      box-shadow: 0px 0px 20px rgba(0, 0, 0, 0.1);
+    `,
+  ];
+});
+
+export const CardTitle = styled.div(() => {
+  const theme = useTheme();
+  return [
+    tw`text-center truncate`,
+    css`
+      padding: 8px 23px;
+      margin-bottom: 14px;
+      color: ${theme.color.white};
+      font-weight: ${theme.fontWeight.bold};
+      font-size: 18px;
+      line-height: ${theme.lineHeight['2xl']};
+      background-color: ${theme.color.pink};
+      border-radius: 50px;
+    `,
+  ];
+});
+
+export const CardDescription = styled.div(() => {
+  const theme = useTheme();
+  return [
+    tw`text-center truncate`,
+    css`
+      margin-bottom: 24px;
+      color: ${theme.color['gray-06']};
+      font-size: ${theme.fontSize.s};
+      font-weight: ${theme.fontWeight.regular};
+      line-height: ${theme.lineHeight.m};
+    `,
+  ];
+});
+
+export const CardImage = styled.img(() => {
+  const theme = useTheme();
+  return [tw`w-full`];
+});

--- a/src/components/Main/MainModal/TagModal.tsx
+++ b/src/components/Main/MainModal/TagModal.tsx
@@ -1,0 +1,36 @@
+import React, { useState } from 'react';
+
+import Tab from '@components/Commons/Tab';
+import Modal from '@components/Commons/Modal';
+
+import MostUseTimeDetailModal from './MostUseTimeDetailModal';
+
+import * as S from './TagModal.Styled';
+
+type TabNameType = 'last' | 'this' | 'period';
+
+type Props = {};
+
+const TagModal = (props: Props) => {
+  const [currentTab, setCurrentTab] = useState<TabNameType>('this');
+
+  return (
+    <Modal type="tag" title="웹 서핑 태그">
+      <S.Description>
+        매주 서퍼님이 많이 사용하는 사이트에 맞는 웹 서핑 유형을 알려드려요.
+      </S.Description>
+      <S.CardWrapper>
+        <S.Card>
+          <S.CardTitle>세상이 궁금한 갈매기aaaaaaaaaaa</S.CardTitle>
+          <S.CardDescription>
+            학습 / 교육 /
+            자기계발aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+          </S.CardDescription>
+          <S.CardImage src="https://user-images.githubusercontent.com/48555121/184919245-9d67ae29-6bb4-4138-b62f-95d6c8aff289.png" />
+        </S.Card>
+      </S.CardWrapper>
+    </Modal>
+  );
+};
+
+export default TagModal;

--- a/src/components/Main/MainModal/TagModal.tsx
+++ b/src/components/Main/MainModal/TagModal.tsx
@@ -1,18 +1,16 @@
 import React, { useState } from 'react';
 
-import Tab from '@components/Commons/Tab';
 import Modal from '@components/Commons/Modal';
 
-import MostUseTimeDetailModal from './MostUseTimeDetailModal';
+import { useAppSelector } from '@redux/store';
+import { tagSelector } from '@redux/tag';
 
 import * as S from './TagModal.Styled';
-
-type TabNameType = 'last' | 'this' | 'period';
 
 type Props = {};
 
 const TagModal = (props: Props) => {
-  const [currentTab, setCurrentTab] = useState<TabNameType>('this');
+  const tagData = useAppSelector(tagSelector);
 
   return (
     <Modal type="tag" title="웹 서핑 태그">
@@ -20,14 +18,13 @@ const TagModal = (props: Props) => {
         매주 서퍼님이 많이 사용하는 사이트에 맞는 웹 서핑 유형을 알려드려요.
       </S.Description>
       <S.CardWrapper>
-        <S.Card>
-          <S.CardTitle>세상이 궁금한 갈매기aaaaaaaaaaa</S.CardTitle>
-          <S.CardDescription>
-            학습 / 교육 /
-            자기계발aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-          </S.CardDescription>
-          <S.CardImage src="https://user-images.githubusercontent.com/48555121/184919245-9d67ae29-6bb4-4138-b62f-95d6c8aff289.png" />
-        </S.Card>
+        {tagData?.map((value) => (
+          <S.Card key={value.id}>
+            <S.CardTitle>{value.name}</S.CardTitle>
+            <S.CardDescription>{value.category}</S.CardDescription>
+            <S.CardImage src={value.cardImageUrl} alt={value.name} />
+          </S.Card>
+        ))}
       </S.CardWrapper>
     </Modal>
   );

--- a/src/hooks/useGoogleLogin.ts
+++ b/src/hooks/useGoogleLogin.ts
@@ -4,6 +4,7 @@ import { useAppDispatch } from '@redux/store';
 import { getToken, getUser } from '@redux/user';
 import { getStat } from '@redux/dashboard';
 import { getHistoryList } from '@redux/history';
+import { getAchievements } from '@redux/tag';
 
 import Axios from '@utils/axios';
 
@@ -27,6 +28,7 @@ const useGoogleLoginCb = () => {
         })
       );
       await dispatch(getStat());
+      await dispatch(getAchievements());
     },
   });
 

--- a/src/pages/Options/Options.tsx
+++ b/src/pages/Options/Options.tsx
@@ -9,6 +9,7 @@ import { historyListSelector, getHistoryList } from '@redux/history';
 import { useAppDispatch, useAppSelector } from '@redux/store';
 import { filterOnceAppliedSelector } from '@redux/common';
 import { getStat } from '@redux/dashboard';
+import { getAchievements } from '@redux/tag';
 
 interface Props {
   title: string;
@@ -34,6 +35,7 @@ const Options = (props: Props) => {
       })
     );
     await dispatch(getStat());
+    await dispatch(getAchievements());
     window.dispatchEvent(
       new CustomEvent('WEBSURFER_RELAY_REQUEST', {
         detail: {

--- a/src/redux/common/index.ts
+++ b/src/redux/common/index.ts
@@ -1,7 +1,7 @@
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
 import { RootState } from '@redux/store';
 
-export type ModalType = 'mostVisit' | 'totalTime' | 'frequency'; //가장 많이 방문, 총 시간, 자주 이용하는 시간
+export type ModalType = 'mostVisit' | 'totalTime' | 'frequency' | 'tag'; //가장 많이 방문, 총 시간, 자주 이용하는 시간, 태그
 
 interface CommonState {
   modal: {

--- a/src/redux/store.ts
+++ b/src/redux/store.ts
@@ -6,12 +6,14 @@ import userReducer from './user';
 import hisoryReducer from './history';
 import commonReducer from './common';
 import dashboardReducer from './dashboard';
+import tagReducer from './tag';
 
 export const store = configureStore({
   reducer: {
     user: userReducer,
     common: commonReducer,
     dashboard: dashboardReducer,
+    tag: tagReducer,
     history: hisoryReducer,
   },
   middleware: (getDefaultMiddleware) => getDefaultMiddleware().concat([thunk]),

--- a/src/redux/tag/index.ts
+++ b/src/redux/tag/index.ts
@@ -1,0 +1,34 @@
+import { createSlice, PayloadAction } from '@reduxjs/toolkit';
+
+import { getAchievements } from './thunk';
+import { RootState } from '@redux/store';
+import { AchievementsResponse, StatResponse } from '@redux/webSerfer.type';
+
+const initialState: { data?: AchievementsResponse[] } = {};
+
+export const achievementsSlice = createSlice({
+  name: 'tag',
+  initialState,
+  reducers: {},
+  extraReducers: (builder) => {
+    builder.addCase(
+      getAchievements.fulfilled,
+      (state, { payload }: PayloadAction<AchievementsResponse[]>) => {
+        console.log(payload);
+        state.data = payload;
+      }
+    );
+    builder.addCase(getAchievements.rejected, (state, action) => {
+      if (action.payload) {
+        console.error('에러가 발생했습니다.', action.payload.errorMessage);
+      } else {
+        console.error('알 수 없는 에러가 발생했습니다.', action.error);
+      }
+    });
+  },
+});
+
+export const tagSelector = (state: RootState) => state.tag.data;
+
+export default achievementsSlice.reducer;
+export * from './thunk';

--- a/src/redux/tag/service.ts
+++ b/src/redux/tag/service.ts
@@ -1,0 +1,13 @@
+import { AxiosResponse } from 'axios';
+
+import Axios from '@utils/axios';
+
+const getData = ({ data }: AxiosResponse) => data;
+
+const apis = {
+  getAchievements() {
+    return Axios.get('/achievements').then(getData);
+  },
+};
+
+export default apis;

--- a/src/redux/tag/thunk.ts
+++ b/src/redux/tag/thunk.ts
@@ -1,0 +1,25 @@
+import { AchievementsResponse } from '@redux/webSerfer.type';
+import { createAsyncThunk } from '@reduxjs/toolkit';
+
+import apiClient from './service';
+
+interface MyKnownError {
+  errorMessage: string;
+}
+
+const name = 'tag';
+
+export const getAchievements = createAsyncThunk<
+  AchievementsResponse[], // 성공 시 리턴 타입
+  void, // input type
+  { rejectValue: MyKnownError } // thunkApi 정의({dispatch?, state?, extra?, rejectValue?})
+>(`${name}/getAchievements`, async (undefined, thunkApi) => {
+  try {
+    const data = await apiClient.getAchievements();
+    return data;
+  } catch (e) {
+    return thunkApi.rejectWithValue({
+      errorMessage: '알 수 없는 에러가 발생했습니다.',
+    });
+  }
+});

--- a/src/redux/webSerfer.type.ts
+++ b/src/redux/webSerfer.type.ts
@@ -147,3 +147,14 @@ export interface StatResponse {
   duration10: number;
   duration11: number;
 }
+
+export interface AchievementsResponse {
+  id: number;
+  createdAt: Date;
+  updatedAt: Date;
+  name: string;
+  color: string;
+  imageUrl: string;
+  cardImageUrl: string;
+  category: string;
+}

--- a/src/styles/emotion.d.ts
+++ b/src/styles/emotion.d.ts
@@ -10,6 +10,7 @@ declare module '@emotion/react' {
       red: string;
       yellow: string;
       green: string;
+      pink: string;
       black: string;
       white: string;
       bgColor: string;

--- a/src/styles/theme.ts
+++ b/src/styles/theme.ts
@@ -10,6 +10,7 @@ const color = {
   green: '#53D76A',
   black: '#000',
   white: '#FFF',
+  pink: '#FDCCBE',
   bgColor: '#FAFAFA',
   'gray-08': '#171717',
   'gray-07': '#333333',


### PR DESCRIPTION
### 💡 다음 이슈를 해결했어요.

- 웹 서핑 태그 상세 모달을 추가했습니다.
<img width="877" alt="스크린샷 2022-08-18 21 38 45" src="https://user-images.githubusercontent.com/90027202/185396660-df88e3ff-4113-4cde-8d90-9ede28729d0b.png">


<br><br>

### 💡 이슈를 처리하면서 추가된 코드가 있어요.

- `/achievements` API를 연결했습니다. (tag 스토어 추가)

<br><br>


### ✅ 셀프 체크리스트

- [ ] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있습니다. (master/main이 아닙니다.)
- [ ] 커밋 메세지를 컨벤션에 맞추었습니다.
- [ ] 변경 후 코드는 컴파일러/브라우저 warning/error 가 발생시키지 않습니다.
- [ ] 변경 후 코드는 기존의 테스트를 통과합니다.
- [ ] 테스트 추가가 필요한지 검토해보았고, 필요한 경우 테스트를 추가했습니다.
- [ ] docs 수정이 필요한지 검토해보았고, 필요한 경우 docs를 수정했습니다.
