### PR TITLE
add, fix, style 지난 주 데이터 보기 기능 추가, 모달 내부 스크롤 사이즈 수정, 메인 레이아웃 수정

### DIFF
--- a/src/components/Commons/Modal.Styled.ts
+++ b/src/components/Commons/Modal.Styled.ts
@@ -51,7 +51,7 @@ export const ModalContentContainer = styled.div(() => {
     tw`w-full bg-white overflow-hidden relative`,
     css`
       border-radius: 18px;
-      padding: 30px 0;
+      padding: 0;
       height: ${innerHeight > 1000
         ? '800px'
         : `calc(${innerHeight}px - 300px)`};
@@ -67,18 +67,19 @@ export const ModalContentWrapper = styled.div(() => {
     tw`w-full bg-white overflow-y-auto overflow-x-hidden absolute`,
     css`
       left: 0;
-      max-height: calc(${innerHeight}px - 360px);
+      max-height: calc(${innerHeight}px - 300px);
       padding: 0 40px;
     `,
   ];
 });
 export const ModalContent = styled.div(() => {
-  const theme = useTheme();
-
   return [
     css`
       width: 740px;
-      height: 740px;
+      /* height: calc(${innerHeight}px - 360px); */
+      max-height: ${innerHeight > 1000
+        ? '800px'
+        : `calc(${innerHeight}px - 300px)`};
     `,
   ];
 });

--- a/src/components/Commons/Modal.Styled.ts
+++ b/src/components/Commons/Modal.Styled.ts
@@ -78,7 +78,7 @@ export const ModalContent = styled.div(() => {
   return [
     css`
       width: 740px;
-      height: calc(${innerHeight}px - 360px);
+      height: 740px;
     `,
   ];
 });

--- a/src/components/Commons/Tab.Styled.ts
+++ b/src/components/Commons/Tab.Styled.ts
@@ -8,8 +8,13 @@ export const TabWrapper = styled.div(() => {
   return [
     tw`w-full flex justify-between`,
     css`
-      height: 36px;
       margin-bottom: 40px;
+      padding-top: 30px;
+      height: 36px;
+      position: sticky;
+      top: 0px;
+      background-color: ${theme.color.white};
+      z-index: 6;
     `,
   ];
 });
@@ -38,6 +43,7 @@ export const TabItemWrapper = styled.div<T.TabItemWrapperProps>(
           : disabled
           ? theme.color['gray-04']
           : theme.color['gray-06']};
+        background-color: ${theme.color.white};
         &:hover {
           color: ${!disabled ? theme.color.primary : ''};
           border-color: ${!disabled ? theme.color.primary : ''};

--- a/src/components/Grid/Grid.styled.ts
+++ b/src/components/Grid/Grid.styled.ts
@@ -71,7 +71,7 @@ export const LayoutCol = styled(Col)<ColProps>((props) => {
       :last-child {
         width: ${(props.unit ? props.unit : 1) * (GUTTER + UNIT) -
         GUTTER / 2}px;
-        padding: 20px 30px 20px;
+        padding: 20px 30px 0 40px;
       }
     `,
   ];

--- a/src/components/Main/DummyMain/DummyMostVisitWebSite.tsx
+++ b/src/components/Main/DummyMain/DummyMostVisitWebSite.tsx
@@ -8,7 +8,7 @@ type Props = {};
 const MostVisitWebSite = (props: Props) => {
   return (
     <Card.Wrapper margin="0 0 40px 0" height="238px" borderRadius="8px">
-      <Card.Title margin="0 0 24px 0">많이 방문한 웹사이트</Card.Title>
+      <Card.Title margin="0 0 24px 0">자주 방문한 웹사이트</Card.Title>
       <S.ItemCardWrapper>
         <S.ItemCard primary>
           <S.ItemCardTitle primary>Pinterest</S.ItemCardTitle>

--- a/src/components/Main/Main.tsx
+++ b/src/components/Main/Main.tsx
@@ -66,41 +66,32 @@ const Main: React.FC<Props> = ({ rawKeyword, setRawKeyword, user }: Props) => {
                 paddingBottom="60px"
                 backgroundColor="bgColor"
               >
-                <S.Sticky>
-                  <S.MainContentsContainer>
-                    <S.MainContentsWrapper>
-                      <MainTopNav
-                        setIsSetting={setIsSetting}
-                        isSetting={isSetting}
-                      />
-                      <MainTitle
-                        setIsSetting={setIsSetting}
-                        isSetting={isSetting}
-                        user={user}
-                        statData={statData}
-                      />
-                      <MostVisitWebSite statData={statData} />
-                      <S.Justify>
-                        <TotalTime statData={statData} />
-                        <SurffingTime statData={statData} />
-                      </S.Justify>
-                      <S.UpdateWrapper>
-                        <S.UpdateMessage>
-                          마지막 업데이트 : {getFromNow(statData.lastUpdatedAt)}
-                        </S.UpdateMessage>
-                        <S.UpdateIcon
-                          src={RefreshUpdateIcon}
-                          alt="Refresh"
-                          onClick={() => {
-                            dispatch(refreshStat());
-                          }}
-                        />
-                      </S.UpdateWrapper>
-                    </S.MainContentsWrapper>
-                  </S.MainContentsContainer>
-                </S.Sticky>
+                <MainTopNav setIsSetting={setIsSetting} isSetting={isSetting} />
+                <MainTitle
+                  setIsSetting={setIsSetting}
+                  isSetting={isSetting}
+                  user={user}
+                  statData={statData}
+                />
+                <MostVisitWebSite statData={statData} />
+                <S.Justify>
+                  <TotalTime statData={statData} />
+                  <SurffingTime statData={statData} />
+                </S.Justify>
+                <S.UpdateWrapper>
+                  <S.UpdateMessage>
+                    마지막 업데이트 : {getFromNow(statData.lastUpdatedAt)}
+                  </S.UpdateMessage>
+                  <S.UpdateIcon
+                    src={RefreshUpdateIcon}
+                    alt="Refresh"
+                    onClick={() => {
+                      dispatch(refreshStat());
+                    }}
+                  />
+                </S.UpdateWrapper>
               </Grid.LayoutCol>
-              <Grid.LayoutCol paddingBottom="60px" unit={isFocus ? 12 : 4}>
+              <Grid.LayoutCol unit={isFocus ? 12 : 4}>
                 <MainHistory
                   setIsFocus={setIsFocus}
                   isFocus={isFocus}

--- a/src/components/Main/MainContent/MostVisitWebSite.tsx
+++ b/src/components/Main/MainContent/MostVisitWebSite.tsx
@@ -19,7 +19,7 @@ const MostVisitWebSite = ({ statData }: Props) => {
 
   return (
     <Card.Wrapper
-      margin="0 0 1vh 0"
+      margin="0 0 40px 0"
       height="238px"
       borderRadius="8px"
       onClick={requestOpenModal}

--- a/src/components/Main/MainContent/MostVisitWebSite.tsx
+++ b/src/components/Main/MainContent/MostVisitWebSite.tsx
@@ -33,7 +33,9 @@ const MostVisitWebSite = ({ statData }: Props) => {
             return (
               <S.ItemCard key={index} primary={primary}>
                 <S.ItemCardTitle primary={primary} isMain>
-                  {value.website.name}
+                  {value.website.name
+                    ? value.website.name
+                    : value.website.hostname}
                 </S.ItemCardTitle>
                 <S.ItemCardCount primary={primary}>
                   {value.amount}회

--- a/src/components/Main/MainContent/MostVisitWebSite.tsx
+++ b/src/components/Main/MainContent/MostVisitWebSite.tsx
@@ -24,7 +24,7 @@ const MostVisitWebSite = ({ statData }: Props) => {
       borderRadius="8px"
       onClick={requestOpenModal}
     >
-      <Card.Title margin="0 0 24px 0">많이 방문한 웹사이트</Card.Title>
+      <Card.Title margin="0 0 24px 0">자주 방문한 웹사이트</Card.Title>
       <S.ItemCardWrapper>
         {statData?.mostVisitedWebsites.map((value, index) => {
           const primary = false;

--- a/src/components/Main/MainContent/TotalTime.tsx
+++ b/src/components/Main/MainContent/TotalTime.tsx
@@ -52,7 +52,11 @@ const TotalTime = ({ statData }: Props) => {
                   <S.RankList key={index + value.website.name}>
                     <S.RankListNameWrapper>
                       <S.Rank>{index + 1}</S.Rank>
-                      <S.Site>{value.website.name}</S.Site>
+                      <S.Site>
+                        {value.website.name
+                          ? value.website.name
+                          : value.website.hostname}
+                      </S.Site>
                     </S.RankListNameWrapper>
                     <S.UsingTime>
                       {secondsToHourMinute(value.amount, 'hourminute')}

--- a/src/components/Main/MainContent/TotalTime.tsx
+++ b/src/components/Main/MainContent/TotalTime.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
 
 import { useAppDispatch, useAppSelector } from '@redux/store';
-import { hasLastWeekDataSelector, openModal } from '@redux/common';
+import { openModal } from '@redux/common';
+import { dashboardStatPrevSelector } from '@redux/dashboard';
 
 import { secondsToHourMinute } from '@utils/printTime';
 
@@ -14,7 +15,7 @@ type Props = { statData?: StatResponse };
 
 const TotalTime = ({ statData }: Props) => {
   const dispatch = useAppDispatch();
-  const hasLastWeekData = useAppSelector(hasLastWeekDataSelector);
+  const hasLastWeekData = useAppSelector(dashboardStatPrevSelector);
 
   return (
     <>

--- a/src/components/Main/MainHistory/MainHistory.styled.ts
+++ b/src/components/Main/MainHistory/MainHistory.styled.ts
@@ -65,7 +65,8 @@ export const HistoryListWrapper = styled.div(() => {
     `,
     css`
       margin-top: 20px;
-      height: calc(100vh - 240px);
+      height: ${innerHeight < 1080 ? 'calc(100vh - 240px)' : '100vh'};
+      padding-bottom: 60px;
       &::-webkit-scrollbar {
         width: 4px;
       }

--- a/src/components/Main/MainModal/MostUseTimeDetailModal.tsx
+++ b/src/components/Main/MainModal/MostUseTimeDetailModal.tsx
@@ -31,18 +31,18 @@ const MostUseTimeDetailModal = (props: Props) => {
   const statData = useAppSelector(dashboardStatSelector);
   const statPrevData = useAppSelector(dashboardStatPrevSelector);
 
-  const printData = () => {
+  const printData = (() => {
     switch (props.period) {
       case 'this':
         return statData && statData;
       case 'last':
         return statPrevData && statPrevData;
       default:
-        break;
+        return;
     }
-  };
+  })();
 
-  const printDate = () => {
+  const printDate = (() => {
     switch (props.period) {
       case 'this':
         return 0;
@@ -51,16 +51,16 @@ const MostUseTimeDetailModal = (props: Props) => {
       default:
         return 0;
     }
-  };
+  })();
 
   const printMostUseTime = () => {
-    if (printData()) {
+    if (printData) {
       const {
         morningDuration,
         daytimeDuration,
         dinnerDuration,
         nightDuration,
-      } = printData();
+      } = printData;
       const array = [
         { name: 'morning', value: morningDuration },
         { name: 'day', value: daytimeDuration },
@@ -89,18 +89,18 @@ const MostUseTimeDetailModal = (props: Props) => {
   };
 
   const timeChartData = [
-    printData()?.duration3,
-    printData()?.duration4,
-    printData()?.duration5,
-    printData()?.duration6,
-    printData()?.duration7,
-    printData()?.duration8,
-    printData()?.duration9,
-    printData()?.duration10,
-    printData()?.duration11,
-    printData()?.duration0,
-    printData()?.duration1,
-    printData()?.duration2,
+    printData?.duration3,
+    printData?.duration4,
+    printData?.duration5,
+    printData?.duration6,
+    printData?.duration7,
+    printData?.duration8,
+    printData?.duration9,
+    printData?.duration10,
+    printData?.duration11,
+    printData?.duration0,
+    printData?.duration1,
+    printData?.duration2,
   ];
 
   const option = {
@@ -208,8 +208,7 @@ const MostUseTimeDetailModal = (props: Props) => {
   return (
     <>
       <S.PeriodTitle>
-        {printYyyymmddMonday(printDate())} - {printYyyymmddSunday(printDate())}{' '}
-        에는
+        {printYyyymmddMonday(printDate)} - {printYyyymmddSunday(printDate)} 에는
       </S.PeriodTitle>
       <S.TitleWrapper>
         <S.Title>{printMostUseTime()}에 웹서핑을 자주 하셨네요!</S.Title>

--- a/src/components/Main/MainModal/MostUseTimeDetailModal.tsx
+++ b/src/components/Main/MainModal/MostUseTimeDetailModal.tsx
@@ -21,11 +21,6 @@ type Props = {
 };
 
 const MostUseTimeDetailModal = (props: Props) => {
-  const MORNING = '아침(07-12시)';
-  const DAY = '낯(13-17시)';
-  const DINNER = '저녁(18-24시)';
-  const NIGHT = '밤(00-06시)';
-
   const theme = useTheme();
 
   const statData = useAppSelector(dashboardStatSelector);
@@ -53,7 +48,7 @@ const MostUseTimeDetailModal = (props: Props) => {
     }
   })();
 
-  const printMostUseTime = () => {
+  const printMostUseTime = (() => {
     if (printData) {
       const {
         morningDuration,
@@ -75,33 +70,34 @@ const MostUseTimeDetailModal = (props: Props) => {
 
       switch (result?.name) {
         case 'morning':
-          return MORNING;
+          return '아침(07-12시)';
         case 'day':
-          return DAY;
+          return '낯(13-17시)';
         case 'dinner':
-          return DINNER;
+          return '저녁(18-24시)';
         case 'night':
-          return NIGHT;
+          return '밤(00-06시)';
         default:
           break;
       }
     }
-  };
+  })();
 
-  const timeChartData = [
-    printData?.duration3,
-    printData?.duration4,
-    printData?.duration5,
-    printData?.duration6,
-    printData?.duration7,
-    printData?.duration8,
-    printData?.duration9,
-    printData?.duration10,
-    printData?.duration11,
-    printData?.duration0,
-    printData?.duration1,
-    printData?.duration2,
-  ];
+  const timeChartData = (() =>
+    printData && [
+      printData.duration3,
+      printData.duration4,
+      printData.duration5,
+      printData.duration6,
+      printData.duration7,
+      printData.duration8,
+      printData.duration9,
+      printData.duration10,
+      printData.duration11,
+      printData.duration0,
+      printData.duration1,
+      printData.duration2,
+    ])();
 
   const option = {
     grid: {
@@ -211,7 +207,7 @@ const MostUseTimeDetailModal = (props: Props) => {
         {printYyyymmddMonday(printDate)} - {printYyyymmddSunday(printDate)} 에는
       </S.PeriodTitle>
       <S.TitleWrapper>
-        <S.Title>{printMostUseTime()}에 웹서핑을 자주 하셨네요!</S.Title>
+        <S.Title>{printMostUseTime}에 웹서핑을 자주 하셨네요!</S.Title>
       </S.TitleWrapper>
       <ReactECharts
         option={option}

--- a/src/components/Main/MainModal/MostUseTimeDetailModal.tsx
+++ b/src/components/Main/MainModal/MostUseTimeDetailModal.tsx
@@ -1,14 +1,16 @@
 import React, { useState } from 'react';
 
-import dayjs from 'dayjs';
 import { useTheme } from '@emotion/react';
 import ReactECharts from 'echarts-for-react';
 
 import PeriodSelector from './PeriodSelector';
 import { useAppSelector } from '@redux/store';
-import { dashboardStatSelector } from '@redux/dashboard';
+import {
+  dashboardStatPrevSelector,
+  dashboardStatSelector,
+} from '@redux/dashboard';
 
-import { printYyyymmddM7, printYyyymmddToday } from '@utils/printTime';
+import { printYyyymmddMonday, printYyyymmddSunday } from '@utils/printTime';
 
 import { FilterType } from './MostVisitWebSIteModal.type';
 
@@ -19,7 +21,6 @@ type Props = {
 };
 
 const MostUseTimeDetailModal = (props: Props) => {
-  const DATE_FORMAT = 'YYYY[년] MM[월] DD[일]';
   const MORNING = '아침(07-12시)';
   const DAY = '낯(13-17시)';
   const DINNER = '저녁(18-24시)';
@@ -28,15 +29,38 @@ const MostUseTimeDetailModal = (props: Props) => {
   const theme = useTheme();
 
   const statData = useAppSelector(dashboardStatSelector);
+  const statPrevData = useAppSelector(dashboardStatPrevSelector);
+
+  const printData = () => {
+    switch (props.period) {
+      case 'this':
+        return statData && statData;
+      case 'last':
+        return statPrevData && statPrevData;
+      default:
+        break;
+    }
+  };
+
+  const printDate = () => {
+    switch (props.period) {
+      case 'this':
+        return 0;
+      case 'last':
+        return -1;
+      default:
+        return 0;
+    }
+  };
 
   const printMostUseTime = () => {
-    if (statData) {
+    if (printData()) {
       const {
         morningDuration,
         daytimeDuration,
         dinnerDuration,
         nightDuration,
-      } = statData;
+      } = printData();
       const array = [
         { name: 'morning', value: morningDuration },
         { name: 'day', value: daytimeDuration },
@@ -65,18 +89,18 @@ const MostUseTimeDetailModal = (props: Props) => {
   };
 
   const timeChartData = [
-    statData?.duration3,
-    statData?.duration4,
-    statData?.duration5,
-    statData?.duration6,
-    statData?.duration7,
-    statData?.duration8,
-    statData?.duration9,
-    statData?.duration10,
-    statData?.duration11,
-    statData?.duration0,
-    statData?.duration1,
-    statData?.duration2,
+    printData()?.duration3,
+    printData()?.duration4,
+    printData()?.duration5,
+    printData()?.duration6,
+    printData()?.duration7,
+    printData()?.duration8,
+    printData()?.duration9,
+    printData()?.duration10,
+    printData()?.duration11,
+    printData()?.duration0,
+    printData()?.duration1,
+    printData()?.duration2,
   ];
 
   const option = {
@@ -175,8 +199,6 @@ const MostUseTimeDetailModal = (props: Props) => {
     ],
   };
 
-  const dummy = ['', '', '', '', '', '', '', ''];
-
   const [isFilterActive, setIsFilterActive] = useState<boolean>(false);
   const [filter, setFilter] = useState<FilterType>({
     startDate: undefined,
@@ -186,7 +208,8 @@ const MostUseTimeDetailModal = (props: Props) => {
   return (
     <>
       <S.PeriodTitle>
-        {printYyyymmddM7} - {printYyyymmddToday} 에는
+        {printYyyymmddMonday(printDate())} - {printYyyymmddSunday(printDate())}{' '}
+        에는
       </S.PeriodTitle>
       <S.TitleWrapper>
         <S.Title>{printMostUseTime()}에 웹서핑을 자주 하셨네요!</S.Title>

--- a/src/components/Main/MainModal/MostUseTimeModal.tsx
+++ b/src/components/Main/MainModal/MostUseTimeModal.tsx
@@ -33,7 +33,7 @@ const MostUseTimeModal = (props: Props) => {
             onClick: () => {
               setCurrentTab('last');
             },
-            disabled: !hasLastWeekData,
+            disabled: hasLastWeekData.daiilyReports.length === 0,
           },
         ]}
       />

--- a/src/components/Main/MainModal/MostUseTimeModal.tsx
+++ b/src/components/Main/MainModal/MostUseTimeModal.tsx
@@ -6,7 +6,7 @@ import Modal from '@components/Commons/Modal';
 import MostUseTimeDetailModal from './MostUseTimeDetailModal';
 
 import { useAppSelector } from '@redux/store';
-import { hasLastWeekDataSelector } from '@redux/common';
+import { dashboardStatPrevSelector } from '@redux/dashboard';
 
 type TabNameType = 'last' | 'this';
 
@@ -14,7 +14,7 @@ type Props = {};
 
 const MostUseTimeModal = (props: Props) => {
   const [currentTab, setCurrentTab] = useState<TabNameType>('this');
-  const hasLastWeekData = useAppSelector(hasLastWeekDataSelector);
+  const hasLastWeekData = useAppSelector(dashboardStatPrevSelector);
 
   return (
     <Modal type="frequency" title="자주 사용한 시간대">

--- a/src/components/Main/MainModal/MostVisitWebSIteModal.Styled.ts
+++ b/src/components/Main/MainModal/MostVisitWebSIteModal.Styled.ts
@@ -4,11 +4,18 @@ import tw, { styled } from 'twin.macro';
 
 import * as T from './MostVisitWebSIteModal.Styled.type';
 
+export const MostVisitWrapper = styled.div(() => {
+  return css`
+    padding-bottom: 60px;
+  `;
+});
+
 export const PeriodTitle = styled.div(() => {
   const theme = useTheme();
   return [
     // tw``,
     css`
+      padding-top: 39px;
       margin-bottom: 8px;
       color: ${theme.color['gray-07']};
       font-size: ${theme.fontSize.m};
@@ -38,6 +45,7 @@ export const SiteListContainer = styled.a(() => {
     tw`flex w-full items-center justify-between no-underline`,
     css`
       height: 56px;
+      /* padding-bottom: 60px; */
       border-style: solid;
       border-width: 1px 0 0 0;
       border-color: ${theme.color['gray-03']};

--- a/src/components/Main/MainModal/MostVisitWebSIteModal.tsx
+++ b/src/components/Main/MainModal/MostVisitWebSIteModal.tsx
@@ -6,7 +6,6 @@ import Modal from '@components/Commons/Modal';
 import MostVisitWebSiteModalContent from './MostVisitWebSiteModalContent';
 
 import { useAppSelector } from '@redux/store';
-import { hasLastWeekDataSelector } from '@redux/common';
 import { dashboardStatPrevSelector } from '@redux/dashboard';
 
 type TabNameType = 'last' | 'this';

--- a/src/components/Main/MainModal/MostVisitWebSIteModal.tsx
+++ b/src/components/Main/MainModal/MostVisitWebSIteModal.tsx
@@ -33,7 +33,7 @@ const MostVisitWebSIteModal = (props: Props) => {
             onClick: () => {
               setCurrentTab('last');
             },
-            disabled: !hasLastWeekData,
+            disabled: hasLastWeekData.daiilyReports.length === 0,
           },
         ]}
       />

--- a/src/components/Main/MainModal/MostVisitWebSIteModal.tsx
+++ b/src/components/Main/MainModal/MostVisitWebSIteModal.tsx
@@ -7,6 +7,7 @@ import MostVisitWebSiteModalThis from './MostVisitWebSiteModalThis';
 
 import { useAppSelector } from '@redux/store';
 import { hasLastWeekDataSelector } from '@redux/common';
+import { dashboardStatPrevSelector } from '@redux/dashboard';
 
 type TabNameType = 'last' | 'this';
 
@@ -14,7 +15,7 @@ type Props = {};
 
 const MostVisitWebSIteModal = (props: Props) => {
   const [currentTab, setCurrentTab] = useState<TabNameType>('this');
-  const hasLastWeekData = useAppSelector(hasLastWeekDataSelector);
+  const hasLastWeekData = useAppSelector(dashboardStatPrevSelector);
 
   return (
     <Modal type="mostVisit" title="자주 방문한 웹사이트">
@@ -38,8 +39,8 @@ const MostVisitWebSIteModal = (props: Props) => {
         ]}
       />
 
-      {currentTab === 'this' && <MostVisitWebSiteModalThis />}
-      {currentTab === 'last' && <MostVisitWebSiteModalThis />}
+      {currentTab === 'this' && <MostVisitWebSiteModalThis period="this" />}
+      {currentTab === 'last' && <MostVisitWebSiteModalThis period="last" />}
     </Modal>
   );
 };

--- a/src/components/Main/MainModal/MostVisitWebSIteModal.tsx
+++ b/src/components/Main/MainModal/MostVisitWebSIteModal.tsx
@@ -3,7 +3,7 @@ import React, { useState } from 'react';
 import Tab from '@components/Commons/Tab';
 import Modal from '@components/Commons/Modal';
 
-import MostVisitWebSiteModalThis from './MostVisitWebSiteModalThis';
+import MostVisitWebSiteModalContent from './MostVisitWebSiteModalContent';
 
 import { useAppSelector } from '@redux/store';
 import { hasLastWeekDataSelector } from '@redux/common';
@@ -39,8 +39,8 @@ const MostVisitWebSIteModal = (props: Props) => {
         ]}
       />
 
-      {currentTab === 'this' && <MostVisitWebSiteModalThis period="this" />}
-      {currentTab === 'last' && <MostVisitWebSiteModalThis period="last" />}
+      {currentTab === 'this' && <MostVisitWebSiteModalContent period="this" />}
+      {currentTab === 'last' && <MostVisitWebSiteModalContent period="last" />}
     </Modal>
   );
 };

--- a/src/components/Main/MainModal/MostVisitWebSiteModalContent.tsx
+++ b/src/components/Main/MainModal/MostVisitWebSiteModalContent.tsx
@@ -17,18 +17,18 @@ const MostVisitWebSiteModalContent = (props: Props) => {
   const statData = useAppSelector(dashboardStatSelector);
   const statPrevData = useAppSelector(dashboardStatPrevSelector);
 
-  const printData = () => {
+  const printData = (() => {
     switch (props.period) {
       case 'this':
         return statData && statData;
       case 'last':
         return statPrevData && statPrevData;
       default:
-        break;
+        return;
     }
-  };
+  })();
 
-  const printDate = () => {
+  const printDate = (() => {
     switch (props.period) {
       case 'this':
         return 0;
@@ -37,16 +37,15 @@ const MostVisitWebSiteModalContent = (props: Props) => {
       default:
         return 0;
     }
-  };
+  })();
 
-  return printData() && printData().mostVisitedWebsites[0] ? (
+  return printData.mostVisitedWebsites[0] ? (
     <S.MostVisitWrapper>
       <S.PeriodTitle>
-        {printYyyymmddMonday(printDate())} - {printYyyymmddSunday(printDate())}{' '}
-        에는
+        {printYyyymmddMonday(printDate)} - {printYyyymmddSunday(printDate)} 에는
       </S.PeriodTitle>
       <S.Title>
-        {printData().mostVisitedWebsites[0].website.name} 에 자주 방문하셨네요!
+        {printData.mostVisitedWebsites[0].website.name} 에 자주 방문하셨네요!
       </S.Title>
 
       <Card.ItemCardWrapper style={{ marginBottom: '20px' }}>
@@ -80,7 +79,7 @@ const MostVisitWebSiteModalContent = (props: Props) => {
         })}
       </Card.ItemCardWrapper>
 
-      {printData().mostVisitedWebsites.map(
+      {printData.mostVisitedWebsites.map(
         (value, index) =>
           index >= 3 && (
             <S.SiteListContainer

--- a/src/components/Main/MainModal/MostVisitWebSiteModalContent.tsx
+++ b/src/components/Main/MainModal/MostVisitWebSiteModalContent.tsx
@@ -13,7 +13,7 @@ import NoDataModal from './NoDataModal';
 
 type Props = { period: string | number };
 
-const MostVisitWebSiteModalThis = (props: Props) => {
+const MostVisitWebSiteModalContent = (props: Props) => {
   const statData = useAppSelector(dashboardStatSelector);
   const statPrevData = useAppSelector(dashboardStatPrevSelector);
 
@@ -109,4 +109,4 @@ const MostVisitWebSiteModalThis = (props: Props) => {
   );
 };
 
-export default MostVisitWebSiteModalThis;
+export default MostVisitWebSiteModalContent;

--- a/src/components/Main/MainModal/MostVisitWebSiteModalContent.tsx
+++ b/src/components/Main/MainModal/MostVisitWebSiteModalContent.tsx
@@ -68,7 +68,9 @@ const MostVisitWebSiteModalContent = (props: Props) => {
                   }}
                 />
                 <Card.ItemCardTitle primary={primary}>
-                  {value.website.name}
+                  {value.website.name
+                    ? value.website.name
+                    : value.website.hostname}
                 </Card.ItemCardTitle>
                 <Card.ItemCardCount primary={primary}>
                   {value.amount}회
@@ -96,7 +98,11 @@ const MostVisitWebSiteModalContent = (props: Props) => {
                     currentTarget.src = `./assets/basic_favicon_32.png`;
                   }}
                 />
-                <S.SiteListTitle>{value.website.name}</S.SiteListTitle>
+                <S.SiteListTitle>
+                  {value.website.name
+                    ? value.website.name
+                    : value.website.hostname}
+                </S.SiteListTitle>
               </S.SiteInformationWrapper>
               <S.SiteListCount>{value.amount}회</S.SiteListCount>
             </S.SiteListContainer>

--- a/src/components/Main/MainModal/MostVisitWebSiteModalContent.tsx
+++ b/src/components/Main/MainModal/MostVisitWebSiteModalContent.tsx
@@ -40,7 +40,7 @@ const MostVisitWebSiteModalContent = (props: Props) => {
   };
 
   return printData() && printData().mostVisitedWebsites[0] ? (
-    <>
+    <S.MostVisitWrapper>
       <S.PeriodTitle>
         {printYyyymmddMonday(printDate())} - {printYyyymmddSunday(printDate())}{' '}
         에는
@@ -103,7 +103,7 @@ const MostVisitWebSiteModalContent = (props: Props) => {
             </S.SiteListContainer>
           )
       )}
-    </>
+    </S.MostVisitWrapper>
   ) : (
     <NoDataModal />
   );

--- a/src/components/Main/MainModal/MostVisitWebSiteModalThis.tsx
+++ b/src/components/Main/MainModal/MostVisitWebSiteModalThis.tsx
@@ -1,27 +1,52 @@
 import React from 'react';
 
 import { useAppSelector } from '@redux/store';
-import { printYyyymmddM7, printYyyymmddToday } from '@utils/printTime';
-import { dashboardStatSelector } from '@redux/dashboard';
-
-import { ModalCloseIcon } from '@assets/img/svg-icon-paths';
+import { printYyyymmddMonday, printYyyymmddSunday } from '@utils/printTime';
+import {
+  dashboardStatPrevSelector,
+  dashboardStatSelector,
+} from '@redux/dashboard';
 
 import * as S from './MostVisitWebSIteModal.Styled';
 import * as Card from '@components/Main/MainContent/MostVisitWebSite.styled';
 import NoDataModal from './NoDataModal';
 
-type Props = {};
+type Props = { period: string | number };
 
 const MostVisitWebSiteModalThis = (props: Props) => {
   const statData = useAppSelector(dashboardStatSelector);
+  const statPrevData = useAppSelector(dashboardStatPrevSelector);
 
-  return statData && statData.mostVisitedWebsites[0] ? (
+  const printData = () => {
+    switch (props.period) {
+      case 'this':
+        return statData && statData;
+      case 'last':
+        return statPrevData && statPrevData;
+      default:
+        break;
+    }
+  };
+
+  const printDate = () => {
+    switch (props.period) {
+      case 'this':
+        return 0;
+      case 'last':
+        return -1;
+      default:
+        return 0;
+    }
+  };
+
+  return printData() && printData().mostVisitedWebsites[0] ? (
     <>
       <S.PeriodTitle>
-        {printYyyymmddM7} - {printYyyymmddToday} 에는
+        {printYyyymmddMonday(printDate())} - {printYyyymmddSunday(printDate())}{' '}
+        에는
       </S.PeriodTitle>
       <S.Title>
-        {statData.mostVisitedWebsites[0].website.name} 에 자주 방문하셨네요!
+        {printData().mostVisitedWebsites[0].website.name} 에 자주 방문하셨네요!
       </S.Title>
 
       <Card.ItemCardWrapper style={{ marginBottom: '20px' }}>
@@ -55,7 +80,7 @@ const MostVisitWebSiteModalThis = (props: Props) => {
         })}
       </Card.ItemCardWrapper>
 
-      {statData.mostVisitedWebsites.map(
+      {printData().mostVisitedWebsites.map(
         (value, index) =>
           index >= 3 && (
             <S.SiteListContainer

--- a/src/components/Main/MainModal/TotalTimeModal.styled.ts
+++ b/src/components/Main/MainModal/TotalTimeModal.styled.ts
@@ -9,6 +9,7 @@ export const PeriodTitle = styled.div(() => {
   return [
     // tw``,
     css`
+      padding-top: 39px;
       margin-bottom: 8px;
       color: ${theme.color['gray-07']};
       font-size: ${theme.fontSize.m};
@@ -75,6 +76,7 @@ export const StayTimeListContainer = styled.ul(() => {
     tw`w-full list-none p-0`,
     css`
       margin-bottom: 30px;
+      padding-bottom: 60px;
     `,
   ];
 });

--- a/src/components/Main/MainModal/TotalTimeModal.tsx
+++ b/src/components/Main/MainModal/TotalTimeModal.tsx
@@ -33,7 +33,7 @@ const TotalTimeModal = (props: Props) => {
             onClick: () => {
               setCurrentTab('last');
             },
-            disabled: !hasLastWeekData,
+            disabled: hasLastWeekData.daiilyReports.length === 0,
           },
         ]}
       />

--- a/src/components/Main/MainModal/TotalTimeModal.tsx
+++ b/src/components/Main/MainModal/TotalTimeModal.tsx
@@ -6,7 +6,7 @@ import Modal from '@components/Commons/Modal';
 import TotalTimeModalDetail from './TotalTimeModalDetail';
 
 import { useAppSelector } from '@redux/store';
-import { hasLastWeekDataSelector } from '@redux/common';
+import { dashboardStatPrevSelector } from '@redux/dashboard';
 
 type TabNameType = 'last' | 'this';
 
@@ -14,7 +14,7 @@ type Props = {};
 
 const TotalTimeModal = (props: Props) => {
   const [currentTab, setCurrentTab] = useState<TabNameType>('this');
-  const hasLastWeekData = useAppSelector(hasLastWeekDataSelector);
+  const hasLastWeekData = useAppSelector(dashboardStatPrevSelector);
 
   return (
     <Modal type="totalTime" title="총 사용 시간">

--- a/src/components/Main/MainModal/TotalTimeModalDetail.tsx
+++ b/src/components/Main/MainModal/TotalTimeModalDetail.tsx
@@ -6,7 +6,6 @@ import ReactECharts from 'echarts-for-react';
 import PeriodSelector from './PeriodSelector';
 
 import { useAppSelector } from '@redux/store';
-import { hasLastWeekDataSelector } from '@redux/common';
 import {
   dashboardStatPrevSelector,
   dashboardStatSelector,
@@ -36,7 +35,7 @@ const TotalTimeModalDetail = (props: Props) => {
     dashboardStatSelector
   );
   const statPrevData = useAppSelector(dashboardStatPrevSelector);
-  const hasLastWeekData = useAppSelector(hasLastWeekDataSelector);
+  const hasLastWeekData = useAppSelector(dashboardStatPrevSelector);
 
   const printData = () => {
     switch (props.period) {

--- a/src/components/Main/MainModal/TotalTimeModalDetail.tsx
+++ b/src/components/Main/MainModal/TotalTimeModalDetail.tsx
@@ -7,10 +7,13 @@ import PeriodSelector from './PeriodSelector';
 
 import { useAppSelector } from '@redux/store';
 import { hasLastWeekDataSelector } from '@redux/common';
-import { dashboardStatSelector } from '@redux/dashboard';
 import {
-  printYyyymmddM7,
-  printYyyymmddToday,
+  dashboardStatPrevSelector,
+  dashboardStatSelector,
+} from '@redux/dashboard';
+import {
+  printYyyymmddMonday,
+  printYyyymmddSunday,
   secondsToHourMinute,
 } from '@utils/printTime';
 
@@ -28,15 +31,36 @@ interface Iacc {
 }
 
 const TotalTimeModalDetail = (props: Props) => {
-  const DATE_FORMAT = 'YYYY[년] MM[월] DD[일]';
-
   const theme = useTheme();
   const statData: StatResponse | undefined = useAppSelector(
     dashboardStatSelector
   );
+  const statPrevData = useAppSelector(dashboardStatPrevSelector);
   const hasLastWeekData = useAppSelector(hasLastWeekDataSelector);
 
-  const { daiilyReports = [], todayDuration } = statData;
+  const printData = () => {
+    switch (props.period) {
+      case 'this':
+        return statData && statData;
+      case 'last':
+        return statPrevData && statPrevData;
+      default:
+        break;
+    }
+  };
+
+  const printDate = () => {
+    switch (props.period) {
+      case 'this':
+        return 0;
+      case 'last':
+        return -1;
+      default:
+        return 0;
+    }
+  };
+
+  const { daiilyReports = [], todayDuration } = printData();
 
   const dataMap = daiilyReports.reduce(
     (acc: Iacc, value) => {
@@ -133,15 +157,19 @@ const TotalTimeModalDetail = (props: Props) => {
 
   return (
     <>
-      {statData && (
+      {printData() && (
         <>
           <S.PeriodTitle>
-            {printYyyymmddM7} - {printYyyymmddToday} 에는
+            {printYyyymmddMonday(printDate())} -{' '}
+            {printYyyymmddSunday(printDate())} 에는
           </S.PeriodTitle>
           <S.TitleWrapper>
             <S.Title>
-              {`${secondsToHourMinute(statData.totalDuration, 'hourminute')}`}을
-              사용하셨네요!
+              {`${secondsToHourMinute(
+                printData().totalDuration,
+                'hourminute'
+              )}`}
+              을 사용하셨네요!
             </S.Title>
             <S.TimeLabel>{hasLastWeekData && '지난주보다 20분 ↑'}</S.TimeLabel>
           </S.TitleWrapper>
@@ -153,11 +181,11 @@ const TotalTimeModalDetail = (props: Props) => {
               marginBottom: '30px',
             }}
           />
-          {statData?.mostDurationWebsites?.[0] && (
+          {printData()?.mostDurationWebsites?.[0] && (
             <>
               <S.SubTitle>사이트별 체류시간</S.SubTitle>
               <S.StayTimeListContainer>
-                {statData.mostDurationWebsites.map((value, index) => (
+                {printData().mostDurationWebsites.map((value, index) => (
                   <S.StyleTimeListWrapper key={index}>
                     <S.Link
                       href={`https://${value.website.hostname}`}

--- a/src/components/Main/MainModal/TotalTimeModalDetail.tsx
+++ b/src/components/Main/MainModal/TotalTimeModalDetail.tsx
@@ -37,18 +37,18 @@ const TotalTimeModalDetail = (props: Props) => {
   const statPrevData = useAppSelector(dashboardStatPrevSelector);
   const hasLastWeekData = useAppSelector(dashboardStatPrevSelector);
 
-  const printData = () => {
+  const printData = (() => {
     switch (props.period) {
       case 'this':
         return statData && statData;
       case 'last':
         return statPrevData && statPrevData;
       default:
-        break;
+        return;
     }
-  };
+  })();
 
-  const printDate = () => {
+  const printDate = (() => {
     switch (props.period) {
       case 'this':
         return 0;
@@ -57,9 +57,9 @@ const TotalTimeModalDetail = (props: Props) => {
       default:
         return 0;
     }
-  };
+  })();
 
-  const { daiilyReports = [], todayDuration } = printData();
+  const { daiilyReports = [], todayDuration } = printData;
 
   const dataMap = daiilyReports.reduce(
     (acc: Iacc, value) => {
@@ -156,18 +156,15 @@ const TotalTimeModalDetail = (props: Props) => {
 
   return (
     <>
-      {printData() && (
+      {printData && (
         <>
           <S.PeriodTitle>
-            {printYyyymmddMonday(printDate())} -{' '}
-            {printYyyymmddSunday(printDate())} 에는
+            {printYyyymmddMonday(printDate)} - {printYyyymmddSunday(printDate)}{' '}
+            에는
           </S.PeriodTitle>
           <S.TitleWrapper>
             <S.Title>
-              {`${secondsToHourMinute(
-                printData().totalDuration,
-                'hourminute'
-              )}`}
+              {`${secondsToHourMinute(printData.totalDuration, 'hourminute')}`}
               을 사용하셨네요!
             </S.Title>
             <S.TimeLabel>{hasLastWeekData && '지난주보다 20분 ↑'}</S.TimeLabel>
@@ -180,11 +177,11 @@ const TotalTimeModalDetail = (props: Props) => {
               marginBottom: '30px',
             }}
           />
-          {printData()?.mostDurationWebsites?.[0] && (
+          {printData?.mostDurationWebsites?.[0] && (
             <>
               <S.SubTitle>사이트별 체류시간</S.SubTitle>
               <S.StayTimeListContainer>
-                {printData().mostDurationWebsites.map((value, index) => (
+                {printData.mostDurationWebsites.map((value, index) => (
                   <S.StyleTimeListWrapper key={index}>
                     <S.Link
                       href={`https://${value.website.hostname}`}
@@ -204,7 +201,9 @@ const TotalTimeModalDetail = (props: Props) => {
                         href={`https://${value.website.hostname}`}
                         target="_blank"
                       >
-                        {value.website.name}
+                        {value.website.name
+                          ? value.website.name
+                          : value.website.hostname}
                       </S.InformationTitle>
                       <S.InformationTimeBarWrapper>
                         <S.InformationTimeBar

--- a/src/hooks/useGoogleLogin.ts
+++ b/src/hooks/useGoogleLogin.ts
@@ -2,7 +2,7 @@ import { useGoogleLogin } from '@react-oauth/google';
 
 import { useAppDispatch } from '@redux/store';
 import { getToken, getUser } from '@redux/user';
-import { getStat } from '@redux/dashboard';
+import { getStat, getStatPrev } from '@redux/dashboard';
 import { getHistoryList } from '@redux/history';
 import { setMainLoading } from '@redux/common';
 import { getAchievements } from '@redux/tag';
@@ -32,6 +32,7 @@ const useGoogleLoginCb = () => {
         })
       );
       await dispatch(getStat());
+      await dispatch(getStatPrev());
       await dispatch(getAchievements());
 
       dispatch(setMainLoading(false));

--- a/src/pages/Options/Options.tsx
+++ b/src/pages/Options/Options.tsx
@@ -13,7 +13,7 @@ import {
   mainLoadingSelector,
   setMainLoading,
 } from '@redux/common';
-import { getStat } from '@redux/dashboard';
+import { getStat, getStatPrev } from '@redux/dashboard';
 import { getAchievements } from '@redux/tag';
 
 import theme from '@styles/theme';
@@ -44,6 +44,7 @@ const Options = (props: Props) => {
       })
     );
     await dispatch(getStat());
+    await dispatch(getStatPrev());
     await dispatch(getAchievements());
     window.dispatchEvent(
       new CustomEvent('WEBSURFER_RELAY_REQUEST', {

--- a/src/pages/Popup/Popup.tsx
+++ b/src/pages/Popup/Popup.tsx
@@ -15,7 +15,11 @@ import { HistoryListReponse, HistoryEntity } from '@redux/webSerfer.type';
 import { historyListSelector, getHistoryList } from '@redux/history';
 import { getUser, userSelector, setToken } from '@redux/user';
 import { filterOnceAppliedSelector } from '@redux/common';
-import { getStat, dashboardAchievementSelector } from '@redux/dashboard';
+import {
+  getStat,
+  dashboardAchievementSelector,
+  getStatPrev,
+} from '@redux/dashboard';
 
 import 'react-toastify/dist/ReactToastify.css';
 
@@ -50,6 +54,7 @@ const Popup = () => {
           })
         );
         await dispatch(getStat());
+        await dispatch(getStatPrev());
       }
     });
   }, [dispatch]);

--- a/src/redux/common/index.ts
+++ b/src/redux/common/index.ts
@@ -8,7 +8,6 @@ interface CommonState {
     isOpenModal: boolean;
     isModalType: ModalType;
   };
-  data: { hasLastWeekData: boolean };
   isFilterOnceApplied: boolean;
   mainLoading: boolean;
 }
@@ -17,9 +16,6 @@ const initialState: CommonState = {
   modal: {
     isOpenModal: false,
     isModalType: 'mostVisit',
-  },
-  data: {
-    hasLastWeekData: false,
   },
   isFilterOnceApplied: false,
   mainLoading: false,
@@ -40,9 +36,6 @@ export const commonSlice = createSlice({
     setIsFilterOnceApplied(state, { payload }) {
       state.isFilterOnceApplied = payload;
     },
-    setHasLastWeekData(state, action: PayloadAction<boolean>) {
-      state.data.hasLastWeekData = action.payload;
-    },
     setMainLoading(state, { payload }) {
       state.mainLoading = payload;
     },
@@ -53,18 +46,11 @@ export const filterOnceAppliedSelector = (state: RootState) =>
   state.common.isFilterOnceApplied;
 
 export const modalSelector = (state: RootState) => state.common.modal;
-export const hasLastWeekDataSelector = (state: RootState) =>
-  state.common.data.hasLastWeekData;
 
 export const mainLoadingSelector = (state: RootState) =>
   state.common.mainLoading;
 
-export const {
-  closeModal,
-  openModal,
-  setIsFilterOnceApplied,
-  setHasLastWeekData,
-  setMainLoading,
-} = commonSlice.actions;
+export const { closeModal, openModal, setIsFilterOnceApplied, setMainLoading } =
+  commonSlice.actions;
 
 export default commonSlice.reducer;

--- a/src/redux/dashboard/index.ts
+++ b/src/redux/dashboard/index.ts
@@ -71,10 +71,13 @@ export const dashboardSlice = createSlice({
   },
 });
 
-// export const { } = dashboardSlice.actions;
 export const dashboardStatSelector = (state: RootState) => state.dashboard.stat;
+export const dashboardStatPrevSelector = (state: RootState) =>
+  state.dashboard.statPrev;
 export const dashboardAchievementSelector = (state: RootState) =>
   state.dashboard.stat?.achievement;
+export const dashboardAchievementPrevSelector = (state: RootState) =>
+  state.dashboard.statPrev?.achievement;
 
 export default dashboardSlice.reducer;
 export * from './thunk';

--- a/src/redux/dashboard/index.ts
+++ b/src/redux/dashboard/index.ts
@@ -1,16 +1,18 @@
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
 
-import { getStat, refreshStat } from './thunk';
+import { getStat, refreshStat, getStatPrev } from './thunk';
 import { RootState } from '@redux/store';
 import { StatResponse } from '@redux/webSerfer.type';
 
 interface DashboardState {
   status?: 'loading' | 'finished' | 'error';
   stat?: StatResponse;
+  statPrev?: StatResponse;
 }
 
 const initialState: DashboardState = {
   stat: undefined,
+  statPrev: undefined,
   status: undefined,
 };
 
@@ -31,6 +33,20 @@ export const dashboardSlice = createSlice({
       }
     );
     builder.addCase(getStat.rejected, (state, action) => {
+      if (action.payload) {
+        console.error('에러가 발생했습니다.', action.payload.errorMessage);
+      } else {
+        console.error('알 수 없는 에러가 발생했습니다.', action.error);
+      }
+    });
+
+    builder.addCase(
+      getStatPrev.fulfilled,
+      (state, { payload }: PayloadAction<StatResponse>) => {
+        state.statPrev = payload;
+      }
+    );
+    builder.addCase(getStatPrev.rejected, (state, action) => {
       if (action.payload) {
         console.error('에러가 발생했습니다.', action.payload.errorMessage);
       } else {

--- a/src/redux/dashboard/service.ts
+++ b/src/redux/dashboard/service.ts
@@ -9,6 +9,10 @@ const apis = {
     return Axios.get('/stat').then(getData);
   },
 
+  getStatPrev() {
+    return Axios.get('/stat/prev').then(getData);
+  },
+
   refreshStat() {
     return Axios.post('/stat/refresh').then(getData);
   },

--- a/src/redux/dashboard/thunk.ts
+++ b/src/redux/dashboard/thunk.ts
@@ -24,6 +24,21 @@ export const getStat = createAsyncThunk<
   }
 });
 
+export const getStatPrev = createAsyncThunk<
+  StatResponse, // 성공 시 리턴 타입
+  void, // input type
+  { rejectValue: MyKnownError } // thunkApi 정의({dispatch?, state?, extra?, rejectValue?})
+>(`${name}/getStatPrev`, async (undefined, thunkApi) => {
+  try {
+    const data = await apiClient.getStatPrev();
+    return data;
+  } catch (e) {
+    return thunkApi.rejectWithValue({
+      errorMessage: '알 수 없는 에러가 발생했습니다.',
+    });
+  }
+});
+
 export const refreshStat = createAsyncThunk<
   StatResponse, // 성공 시 리턴 타입
   void, // input type

--- a/src/utils/printTime.ts
+++ b/src/utils/printTime.ts
@@ -1,5 +1,7 @@
 import dayjs from 'dayjs';
 
+const YYYYMMDD = 'YYYY년 MM월 DD일';
+
 export const secondsToHourMinute = (
   seconds: number,
   type: 'hour' | 'minute' | 'hourminute'
@@ -25,7 +27,13 @@ export const minuteToHourMinute = (
   }
 };
 
-export const printYyyymmddToday = dayjs(new Date()).format('YYYY년 MM월 DD일');
-export const printYyyymmddM7 = dayjs(new Date())
-  .add(-7, 'day')
-  .format('YYYY년 MM월 DD일');
+export const printYyyymmddToday = dayjs().format(YYYYMMDD);
+export const printYyyymmddM7 = dayjs().add(-7, 'day').format(YYYYMMDD);
+export const printYyyymmddMonday = (week?: number) =>
+  dayjs()
+    .day(1 + (week ? week : 0) * 7)
+    .format(YYYYMMDD); //한 주의 시작일 (월요일)
+export const printYyyymmddSunday = (week?: number) =>
+  dayjs()
+    .day(7 + (week ? week : 0) * 7)
+    .format(YYYYMMDD); //한 주의 마감일 (일요일)


### PR DESCRIPTION
### 💡 다음 이슈를 해결했어요.

- 지난 주 데이터 Api를 연동했습니다. (stat prev)
<img width="685" alt="스크린샷 2022-09-03 23 52 11" src="https://user-images.githubusercontent.com/90027202/188276000-a0fc2d04-e94d-4551-833a-6b53f265e211.png">
- 모달 사이즈 하단 부분 데이터가 짤리는 부분을 고쳤습니다.
<img width="708" alt="스크린샷 2022-09-03 23 52 29" src="https://user-images.githubusercontent.com/90027202/188276017-c3c6a5e2-9283-4c21-a1f0-6c1a1cc61dd6.png">
- 이번 주, 지난주 출력 날짜를 `월~일요일` 기준으로 변경했습니다.
- 메인 대시보드 쪽 `sticky`속성을 삭제하고 레이아웃 그대로 적용했습니다.
  - sticky, absolute, fixed 모두 크기가 정해져 있어서 기존에 적용했던 그림자가 짤리는 현상이 있었습니다.
  - 추후 레이아웃 회의 후 다시 작업할 때 적절한 코드로 수정하겠습니다.
- 메인 방문기록 쪽 height사이즈를 수정했습니다.
  - 기존에 `calc(100vh - 240px)`부분을 `innerHeight < 1080 ? 'calc(100vh - 240px)' : '100vh'`으로 수정했습니다.
  - 해상도가 낮은 경우에만 일단 하단에 빈 칸이 필요한 것 같아서 임시로 이렇게 처리했구, 나중에 레이아웃 협의 후 다시 적절한 코드로 수정하겠습니다.
  - 쌓인 기록의 홈페이지에 `타이틀 메타` 정보가 없을 때 레이아웃이 깨지는 부분이 있었습니다. 이 부분은 타이틀 정보 대신 그 사이트의 URL을 보여주도록 대체했습니다.
  - tsx 내부에 삽입된 함수 코드에서 iife로 계산된 값을 입력하도록 피드백 반영했습니다.

<br><br>

### 💡 이슈를 처리하면서 추가된 코드가 있어요.

- Redux Common 스토어에 추가했었던 `hasLastWeekData` 상태를 삭제했습니다.
  - prevStat 데이터를 불러오면서 지난주 데이터가 있는지 여부를 따로 관리할 필요가 없어져서 삭제했습니다.
- Redux thunk에 prev stat API를 연결했습니다.
  - 동시에 지난 주 데이터 상태는 `dashboard` 리듀서 안에 prevStat으로 저장하도록 했습니다.
  - [x] 현재 로그인과 동시에 이번 주, 지난 주 데이터를 동시에 가져오는데, 혹시 지난 주 데이터는 지난 주 탭을 클릭했을 때 가져오는게 좋다고 생각하시면 댓글 부탁드립니다. 
  - `printTime.ts`에 `printYyyymmddMonday(week?: number)`와 `printYyyymmddSunday(week?: number)` 함수를 추가했습니다.
    - week에 0을 넣으면 이번 주, 1을 넣으면 다음 주, -1을 넣으면 지난 주 날짜가 계산됩니다.


<br><br>

### ✅ 셀프 체크리스트

- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있습니다. (master/main이 아닙니다.)
- [x] 커밋 메세지를 컨벤션에 맞추었습니다.
- [x] 변경 후 코드는 컴파일러/브라우저 warning/error 가 발생시키지 않습니다.
- [x] 변경 후 코드는 기존의 테스트를 통과합니다.
- [ ] 테스트 추가가 필요한지 검토해보았고, 필요한 경우 테스트를 추가했습니다.
- [ ] docs 수정이 필요한지 검토해보았고, 필요한 경우 docs를 수정했습니다.
